### PR TITLE
Use rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ edition = "2021"
 #secret_sauce = { path = "../secret_sauce", optional = true }
 
 shared = { path = "shared" }
-openssl = "0.10.57"
-actix-web = { version = "4", features = ["openssl"] }
+actix-web = { version = "4", features = ["rustls"] }
+rustls = "0.20.9"
+rustls-pemfile = "1.0.3"
 futures = "0.3.28"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,8 @@ lazy_static! {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {    
-    let cert_file = &mut BufReader::new(File::open("cert.pem").unwrap());
-    let key_file = &mut BufReader::new(File::open("key.pem").unwrap());
+    let cert_file = &mut BufReader::new(File::open("cert.pem")?);
+    let key_file = &mut BufReader::new(File::open("key.pem")?);
 
     let cert = rustls_pemfile::certs(cert_file)?.into_iter().map(Certificate).collect();
     let key = PrivateKey(rustls_pemfile::pkcs8_private_keys(key_file)?.remove(0));


### PR DESCRIPTION
This Pull Request replaces OpenSSL with Rustls to provide broader platform support and easier building (no native libs for openssl required)